### PR TITLE
[update] package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest --watchAll --verbose",
+    "test": "jest --verbose --maxWorkers=2",
     "lint": "eslint .",
     "fix": "eslint . --fix"
   },


### PR DESCRIPTION
Removed the watch flag from jest and added a max workers flag. This will prevent jest from creating too many workers, and from watching code indefinitely (which will disallow the GH Action to finish testing)