### PR TITLE
Hotfix - Allow jest tests to finish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest --watchAll --verbose",
+    "test": "jest --verbose --maxWorkers=2",
     "lint": "eslint .",
     "fix": "eslint . --fix"
   },


### PR DESCRIPTION
By removing the --watchAll flag (which causes tests to be watched indefinitely without completing) and adding the --maxWorkers = 2 flag (which caps the number of jest workers created), we allow the GitHub Action to actually complete.